### PR TITLE
Fixed utf16 parsing

### DIFF
--- a/test/parseTest.js
+++ b/test/parseTest.js
@@ -79,7 +79,7 @@ module.exports = {
   },
 
   'utf16': function (test) {
-    var file = path.join(__dirname, "utf16.plist");
+    var file = path.join(__dirname, "utf16.bplist");
     var startTime = new Date();
 
     bplist.parseFile(file, function (err, dicts) {
@@ -93,6 +93,7 @@ module.exports = {
       var dict = dicts[0];
       test.equal(dict['CFBundleName'], 'sellStuff');
       test.equal(dict['CFBundleShortVersionString'], '2.6.1');
+      test.equal(dict['NSHumanReadableCopyright'], '©2008-2012, sellStuff, Inc.');
       test.done();
     });
   },


### PR DESCRIPTION
I had to switch the toString encoding on the buffer to ucs2 (utf16 little endian), but plist utf16 strings are all big endian so I just did a primitive byte swap.  Seems to work fine now, and I updated the unit test to check for the appropiate characters.
