### PR TITLE
prevent calling callback twice when error thrown

### DIFF
--- a/bplistParser.js
+++ b/bplistParser.js
@@ -15,12 +15,14 @@ var EPOCH = 978307200000;
 
 var parseFile = exports.parseFile = function (fileNameOrBuffer, callback) {
   function tryParseBuffer(buffer) {
+    var err = null;
+    var result;
     try {
-      var result = parseBuffer(buffer);
-      return callback(null, result);
+      result = parseBuffer(buffer);
     } catch (ex) {
-      return callback(ex);
+      err = ex;
     }
+    callback(err, result);
   }
 
   if (Buffer.isBuffer(fileNameOrBuffer)) {


### PR DESCRIPTION
We don't want the callback invocation to be in the try block. Otherwise,
if the callback throws an error, bplist will unintentionally catch it
and then call the callback again.
