### PR TITLE
parse UIDs as objects `{UID: #}` instead of coercing them into integers....

### DIFF
--- a/bplistParser.js
+++ b/bplistParser.js
@@ -13,6 +13,11 @@ exports.maxObjectCount = 32768;
 // So we just hardcode the correct value.
 var EPOCH = 978307200000;
 
+// UID object definition
+var UID = exports.UID = function(id) {
+  this.UID = id;
+}
+
 var parseFile = exports.parseFile = function (fileNameOrBuffer, callback) {
   function tryParseBuffer(buffer) {
     var err = null;
@@ -145,7 +150,7 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
     function parseUID() {
       var length = objInfo + 1;
       if (length < exports.maxObjectSize) {
-        return readUInt(buffer.slice(offset + 1, offset + 1 + length));
+        return new UID(readUInt(buffer.slice(offset + 1, offset + 1 + length)));
       } else {
         throw new Error("To little heap space available! Wanted to read " + length + " bytes, but only " + exports.maxObjectSize + " are available.");
       }

--- a/test/parseTest.js
+++ b/test/parseTest.js
@@ -110,10 +110,10 @@ module.exports = {
       var endTime = new Date();
       console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
 
-      var dict = dicts[0]; 
-      test.deepEqual(dict['$objects'][1]['NS.keys'], [2, 3, 4]);
-      test.deepEqual(dict['$objects'][1]['NS.objects'], [5, 6, 7]);
-      test.equal(dict['$top']['root'], 1);      
+      var dict = dicts[0];
+      test.deepEqual(dict['$objects'][1]['NS.keys'], [{UID:2}, {UID:3}, {UID:4}]);
+      test.deepEqual(dict['$objects'][1]['NS.objects'], [{UID: 5}, {UID:6}, {UID:7}]);
+      test.deepEqual(dict['$top']['root'], {UID:1});
       test.done();
     });
   }


### PR DESCRIPTION
... This way one can parse a bplist and recreate it using bplist-creator. Prior to this commit, UID's in the bplist are converted into plain integers, so when re-encoding the bplist information is lost.