### PR TITLE
Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-bplist-parser
-=============
+# bplist-parser
 
 Binary Mac OS X Plist (property list) parser.
 
@@ -12,13 +11,15 @@ $ npm install bplist-parser
 ## Quick Examples
 
 ```javascript
-var bplist = require('bplist-parser');
+const bplist = require('bplist-parser');
 
-bplist.parseFile('myPlist.bplist', function(err, obj) {
-  if (err) throw err;
+(async () => {
+
+  const obj = await bplist.parseFile('myPlist.bplist');
 
   console.log(JSON.stringify(obj));
-});
+
+})();
 ```
 
 ## License

--- a/bplistParser.js
+++ b/bplistParser.js
@@ -37,15 +37,14 @@ const parseFile = exports.parseFile = function (fileNameOrBuffer, callback) {
 
     if (Buffer.isBuffer(fileNameOrBuffer)) {
       return tryParseBuffer(fileNameOrBuffer);
-    } else {
-      fs.readFile(fileNameOrBuffer, function (err, data) {
-        if (err) {
-          reject(err);
-          return callback(err);
-        }
-        tryParseBuffer(data);
-      });
     }
+    fs.readFile(fileNameOrBuffer, function (err, data) {
+      if (err) {
+        reject(err);
+        return callback(err);
+      }
+      tryParseBuffer(data);
+    });
   });
 };
 
@@ -167,22 +166,22 @@ const parseBuffer = exports.parseBuffer = function (buffer) {
         const data = buffer.slice(offset + 1, offset + 1 + length);
         const str = bufferToHexString(data);
         return bigInt(str, 16);
-      } else if (objInfo == 0x3) {
-        return buffer.readInt32BE(offset + 1);
-      } else if (length < exports.maxObjectSize) {
-        return readUInt(buffer.slice(offset + 1, offset + 1 + length));
-      } else {
-        throw new Error("To little heap space available! Wanted to read " + length + " bytes, but only " + exports.maxObjectSize + " are available.");
       }
+      if (objInfo == 0x3) {
+        return buffer.readInt32BE(offset + 1);
+      }
+      if (length < exports.maxObjectSize) {
+        return readUInt(buffer.slice(offset + 1, offset + 1 + length));
+      }
+      throw new Error("To little heap space available! Wanted to read " + length + " bytes, but only " + exports.maxObjectSize + " are available.");
     }
 
     function parseUID() {
       const length = objInfo + 1;
       if (length < exports.maxObjectSize) {
         return new UID(readUInt(buffer.slice(offset + 1, offset + 1 + length)));
-      } else {
-        throw new Error("To little heap space available! Wanted to read " + length + " bytes, but only " + exports.maxObjectSize + " are available.");
       }
+      throw new Error("To little heap space available! Wanted to read " + length + " bytes, but only " + exports.maxObjectSize + " are available.");
     }
 
     function parseReal() {
@@ -228,9 +227,8 @@ const parseBuffer = exports.parseBuffer = function (buffer) {
       }
       if (length < exports.maxObjectSize) {
         return buffer.slice(offset + dataoffset, offset + dataoffset + length);
-      } else {
-        throw new Error("To little heap space available! Wanted to read " + length + " bytes, but only " + exports.maxObjectSize + " are available.");
       }
+      throw new Error("To little heap space available! Wanted to read " + length + " bytes, but only " + exports.maxObjectSize + " are available.");
     }
 
     function parsePlistString (isUtf16) {
@@ -262,9 +260,8 @@ const parseBuffer = exports.parseBuffer = function (buffer) {
           enc = "ucs2";
         }
         return plistString.toString(enc);
-      } else {
-        throw new Error("To little heap space available! Wanted to read " + length + " bytes, but only " + exports.maxObjectSize + " are available.");
       }
+      throw new Error("To little heap space available! Wanted to read " + length + " bytes, but only " + exports.maxObjectSize + " are available.");
     }
 
     function parseArray() {

--- a/bplistParser.js
+++ b/bplistParser.js
@@ -2,9 +2,9 @@
 
 // adapted from http://code.google.com/p/plist/source/browse/trunk/src/com/dd/plist/BinaryPropertyListParser.java
 
-var fs = require('fs');
-var bigInt = require("big-integer");
-var debug = false;
+const fs = require('fs');
+const bigInt = require("big-integer");
+const debug = false;
 
 exports.maxObjectSize = 100 * 1000 * 1000; // 100Meg
 exports.maxObjectCount = 32768;
@@ -12,18 +12,18 @@ exports.maxObjectCount = 32768;
 // EPOCH = new SimpleDateFormat("yyyy MM dd zzz").parse("2001 01 01 GMT").getTime();
 // ...but that's annoying in a static initializer because it can throw exceptions, ick.
 // So we just hardcode the correct value.
-var EPOCH = 978307200000;
+const EPOCH = 978307200000;
 
 // UID object definition
-var UID = exports.UID = function(id) {
+const UID = exports.UID = function(id) {
   this.UID = id;
-}
+};
 
-var parseFile = exports.parseFile = function (fileNameOrBuffer, callback) {
+const parseFile = exports.parseFile = function (fileNameOrBuffer, callback) {
   return new Promise(function (resolve, reject) {
     function tryParseBuffer(buffer) {
-      var err = null;
-      var result;
+      let err = null;
+      let result;
       try {
         result = parseBuffer(buffer);
         resolve(result);
@@ -49,35 +49,33 @@ var parseFile = exports.parseFile = function (fileNameOrBuffer, callback) {
   });
 };
 
-var parseBuffer = exports.parseBuffer = function (buffer) {
-  var result = {};
-
+const parseBuffer = exports.parseBuffer = function (buffer) {
   // check header
-  var header = buffer.slice(0, 'bplist'.length).toString('utf8');
+  const header = buffer.slice(0, 'bplist'.length).toString('utf8');
   if (header !== 'bplist') {
     throw new Error("Invalid binary plist. Expected 'bplist' at offset 0.");
   }
 
   // Handle trailer, last 32 bytes of the file
-  var trailer = buffer.slice(buffer.length - 32, buffer.length);
+  const trailer = buffer.slice(buffer.length - 32, buffer.length);
   // 6 null bytes (index 0 to 5)
-  var offsetSize = trailer.readUInt8(6);
+  const offsetSize = trailer.readUInt8(6);
   if (debug) {
     console.log("offsetSize: " + offsetSize);
   }
-  var objectRefSize = trailer.readUInt8(7);
+  const objectRefSize = trailer.readUInt8(7);
   if (debug) {
     console.log("objectRefSize: " + objectRefSize);
   }
-  var numObjects = readUInt64BE(trailer, 8);
+  const numObjects = readUInt64BE(trailer, 8);
   if (debug) {
     console.log("numObjects: " + numObjects);
   }
-  var topObject = readUInt64BE(trailer, 16);
+  const topObject = readUInt64BE(trailer, 16);
   if (debug) {
     console.log("topObject: " + topObject);
   }
-  var offsetTableOffset = readUInt64BE(trailer, 24);
+  const offsetTableOffset = readUInt64BE(trailer, 24);
   if (debug) {
     console.log("offsetTableOffset: " + offsetTableOffset);
   }
@@ -87,10 +85,10 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
   }
 
   // Handle offset table
-  var offsetTable = [];
+  const offsetTable = [];
 
-  for (var i = 0; i < numObjects; i++) {
-    var offsetBytes = buffer.slice(offsetTableOffset + i * offsetSize, offsetTableOffset + (i + 1) * offsetSize);
+  for (let i = 0; i < numObjects; i++) {
+    const offsetBytes = buffer.slice(offsetTableOffset + i * offsetSize, offsetTableOffset + (i + 1) * offsetSize);
     offsetTable[i] = readUInt(offsetBytes, 0);
     if (debug) {
       console.log("Offset for Object #" + i + " is " + offsetTable[i] + " [" + offsetTable[i].toString(16) + "]");
@@ -102,10 +100,10 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
   // <a href="http://www.opensource.apple.com/source/CF/CF-635/CFBinaryPList.c">
   // Apple's binary property list parser implementation</a>.
   function parseObject(tableOffset) {
-    var offset = offsetTable[tableOffset];
-    var type = buffer[offset];
-    var objType = (type & 0xF0) >> 4; //First  4 bits
-    var objInfo = (type & 0x0F);      //Second 4 bits
+    const offset = offsetTable[tableOffset];
+    const type = buffer[offset];
+    const objType = (type & 0xF0) >> 4; //First  4 bits
+    const objInfo = (type & 0x0F);      //Second 4 bits
     switch (objType) {
     case 0x0:
       return parseSimple();
@@ -148,26 +146,26 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
     }
 
     function bufferToHexString(buffer) {
-      var str = '';
-      var i;
+      let str = '';
+      let i;
       for (i = 0; i < buffer.length; i++) {
         if (buffer[i] != 0x00) {
           break;
         }
       }
       for (; i < buffer.length; i++) {
-        var part = '00' + buffer[i].toString(16);
+        const part = '00' + buffer[i].toString(16);
         str += part.substr(part.length - 2);
       }
       return str;
     }
 
     function parseInteger() {
-      var length = Math.pow(2, objInfo);
+      const length = Math.pow(2, objInfo);
 
       if (objInfo == 0x4) {
-        var data = buffer.slice(offset + 1, offset + 1 + length);
-        var str = bufferToHexString(data);
+        const data = buffer.slice(offset + 1, offset + 1 + length);
+        const str = bufferToHexString(data);
         return bigInt(str, 16);
       } else if (objInfo == 0x3) {
         return buffer.readInt32BE(offset + 1);
@@ -179,7 +177,7 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
     }
 
     function parseUID() {
-      var length = objInfo + 1;
+      const length = objInfo + 1;
       if (length < exports.maxObjectSize) {
         return new UID(readUInt(buffer.slice(offset + 1, offset + 1 + length)));
       } else {
@@ -188,13 +186,13 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
     }
 
     function parseReal() {
-      var length = Math.pow(2, objInfo);
+      const length = Math.pow(2, objInfo);
       if (length < exports.maxObjectSize) {
-        var realBuffer = buffer.slice(offset + 1, offset + 1 + length);
+        const realBuffer = buffer.slice(offset + 1, offset + 1 + length);
         if (length === 4) {
           return realBuffer.readFloatBE(0);
         }
-        else if (length === 8) {
+        if (length === 8) {
           return realBuffer.readDoubleBE(0);
         }
       } else {
@@ -206,21 +204,21 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
       if (objInfo != 0x3) {
         console.error("Unknown date type :" + objInfo + ". Parsing anyway...");
       }
-      var dateBuffer = buffer.slice(offset + 1, offset + 9);
+      const dateBuffer = buffer.slice(offset + 1, offset + 9);
       return new Date(EPOCH + (1000 * dateBuffer.readDoubleBE(0)));
     }
 
     function parseData() {
-      var dataoffset = 1;
-      var length = objInfo;
+      let dataoffset = 1;
+      let length = objInfo;
       if (objInfo == 0xF) {
-        var int_type = buffer[offset + 1];
-        var intType = (int_type & 0xF0) / 0x10;
+        const int_type = buffer[offset + 1];
+        const intType = (int_type & 0xF0) / 0x10;
         if (intType != 0x1) {
           console.error("0x4: UNEXPECTED LENGTH-INT TYPE! " + intType);
         }
-        var intInfo = int_type & 0x0F;
-        var intLength = Math.pow(2, intInfo);
+        const intInfo = int_type & 0x0F;
+        const intLength = Math.pow(2, intInfo);
         dataoffset = 2 + intLength;
         if (intLength < 3) {
           length = readUInt(buffer.slice(offset + 2, offset + 2 + intLength));
@@ -237,18 +235,18 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
 
     function parsePlistString (isUtf16) {
       isUtf16 = isUtf16 || 0;
-      var enc = "utf8";
-      var length = objInfo;
-      var stroffset = 1;
+      let enc = "utf8";
+      let length = objInfo;
+      let stroffset = 1;
       if (objInfo == 0xF) {
-        var int_type = buffer[offset + 1];
-        var intType = (int_type & 0xF0) / 0x10;
+        const int_type = buffer[offset + 1];
+        const intType = (int_type & 0xF0) / 0x10;
         if (intType != 0x1) {
           console.err("UNEXPECTED LENGTH-INT TYPE! " + intType);
         }
-        var intInfo = int_type & 0x0F;
-        var intLength = Math.pow(2, intInfo);
-        var stroffset = 2 + intLength;
+        const intInfo = int_type & 0x0F;
+        const intLength = Math.pow(2, intInfo);
+        stroffset = 2 + intLength;
         if (intLength < 3) {
           length = readUInt(buffer.slice(offset + 2, offset + 2 + intLength));
         } else {
@@ -258,7 +256,7 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
       // length is String length -> to get byte length multiply by 2, as 1 character takes 2 bytes in UTF-16
       length *= (isUtf16 + 1);
       if (length < exports.maxObjectSize) {
-        var plistString = Buffer.from(buffer.slice(offset + stroffset, offset + stroffset + length));
+        let plistString = Buffer.from(buffer.slice(offset + stroffset, offset + stroffset + length));
         if (isUtf16) {
           plistString = swapBytes(plistString);
           enc = "ucs2";
@@ -270,16 +268,16 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
     }
 
     function parseArray() {
-      var length = objInfo;
-      var arrayoffset = 1;
+      let length = objInfo;
+      let arrayoffset = 1;
       if (objInfo == 0xF) {
-        var int_type = buffer[offset + 1];
-        var intType = (int_type & 0xF0) / 0x10;
+        const int_type = buffer[offset + 1];
+        const intType = (int_type & 0xF0) / 0x10;
         if (intType != 0x1) {
           console.error("0xa: UNEXPECTED LENGTH-INT TYPE! " + intType);
         }
-        var intInfo = int_type & 0x0F;
-        var intLength = Math.pow(2, intInfo);
+        const intInfo = int_type & 0x0F;
+        const intLength = Math.pow(2, intInfo);
         arrayoffset = 2 + intLength;
         if (intLength < 3) {
           length = readUInt(buffer.slice(offset + 2, offset + 2 + intLength));
@@ -290,25 +288,25 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
       if (length * objectRefSize > exports.maxObjectSize) {
         throw new Error("To little heap space available!");
       }
-      var array = [];
-      for (var i = 0; i < length; i++) {
-        var objRef = readUInt(buffer.slice(offset + arrayoffset + i * objectRefSize, offset + arrayoffset + (i + 1) * objectRefSize));
+      const array = [];
+      for (let i = 0; i < length; i++) {
+        const objRef = readUInt(buffer.slice(offset + arrayoffset + i * objectRefSize, offset + arrayoffset + (i + 1) * objectRefSize));
         array[i] = parseObject(objRef);
       }
       return array;
     }
 
     function parseDictionary() {
-      var length = objInfo;
-      var dictoffset = 1;
+      let length = objInfo;
+      let dictoffset = 1;
       if (objInfo == 0xF) {
-        var int_type = buffer[offset + 1];
-        var intType = (int_type & 0xF0) / 0x10;
+        const int_type = buffer[offset + 1];
+        const intType = (int_type & 0xF0) / 0x10;
         if (intType != 0x1) {
           console.error("0xD: UNEXPECTED LENGTH-INT TYPE! " + intType);
         }
-        var intInfo = int_type & 0x0F;
-        var intLength = Math.pow(2, intInfo);
+        const intInfo = int_type & 0x0F;
+        const intLength = Math.pow(2, intInfo);
         dictoffset = 2 + intLength;
         if (intLength < 3) {
           length = readUInt(buffer.slice(offset + 2, offset + 2 + intLength));
@@ -322,12 +320,12 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
       if (debug) {
         console.log("Parsing dictionary #" + tableOffset);
       }
-      var dict = {};
-      for (var i = 0; i < length; i++) {
-        var keyRef = readUInt(buffer.slice(offset + dictoffset + i * objectRefSize, offset + dictoffset + (i + 1) * objectRefSize));
-        var valRef = readUInt(buffer.slice(offset + dictoffset + (length * objectRefSize) + i * objectRefSize, offset + dictoffset + (length * objectRefSize) + (i + 1) * objectRefSize));
-        var key = parseObject(keyRef);
-        var val = parseObject(valRef);
+      const dict = {};
+      for (let i = 0; i < length; i++) {
+        const keyRef = readUInt(buffer.slice(offset + dictoffset + i * objectRefSize, offset + dictoffset + (i + 1) * objectRefSize));
+        const valRef = readUInt(buffer.slice(offset + dictoffset + (length * objectRefSize) + i * objectRefSize, offset + dictoffset + (length * objectRefSize) + (i + 1) * objectRefSize));
+        const key = parseObject(keyRef);
+        const val = parseObject(valRef);
         if (debug) {
           console.log("  DICT #" + tableOffset + ": Mapped " + key + " to " + val);
         }
@@ -343,8 +341,8 @@ var parseBuffer = exports.parseBuffer = function (buffer) {
 function readUInt(buffer, start) {
   start = start || 0;
 
-  var l = 0;
-  for (var i = start; i < buffer.length; i++) {
+  let l = 0;
+  for (let i = start; i < buffer.length; i++) {
     l <<= 8;
     l |= buffer[i] & 0xFF;
   }
@@ -353,14 +351,14 @@ function readUInt(buffer, start) {
 
 // we're just going to toss the high order bits because javascript doesn't have 64-bit ints
 function readUInt64BE(buffer, start) {
-  var data = buffer.slice(start, start + 8);
+  const data = buffer.slice(start, start + 8);
   return data.readUInt32BE(4, 8);
 }
 
 function swapBytes(buffer) {
-  var len = buffer.length;
-  for (var i = 0; i < len; i += 2) {
-    var a = buffer[i];
+  const len = buffer.length;
+  for (let i = 0; i < len; i += 2) {
+    const a = buffer[i];
     buffer[i] = buffer[i+1];
     buffer[i+1] = a;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,975 @@
+{
+  "name": "bplist-parser",
+  "version": "0.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "big-integer": {
+      "version": "1.6.43",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.43.tgz",
+      "integrity": "sha512-9dULc9jsKmXl0Aeunug8wbF+58n+hQoFjqClN7WeZwGLh0XJUWyJJ9Ee+Ep+Ql/J9fRsTVaeThp8MhiCCrY0Jg=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
+      "integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.2.2",
+        "yargs-parser": "13.0.0",
+        "yargs-unparser": "1.5.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "dev": true,
+      "requires": {
+        "cliui": "^4.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.11",
+        "yargs": "^12.0.5"
+      },
+      "dependencies": {
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Binary plist parser.",
   "main": "bplistParser.js",
   "scripts": {
-    "test": "./node_modules/nodeunit/bin/nodeunit test"
+    "test": "mocha test"
   },
   "keywords": [
     "bplist",
@@ -12,15 +12,23 @@
     "parser"
   ],
   "author": "Joe Ferner <joe.ferner@nearinfinity.com>",
+  "contributors": [
+    "Brett Zamir"
+  ],
   "license": "MIT",
   "devDependencies": {
-    "nodeunit": "~0.9.1"
+    "mocha": "^6.1.4"
+  },
+  "homepage": "https://github.com/nearinfinity/node-bplist-parser",
+  "bugs": "https://github.com/nearinfinity/node-bplist-parser/issues",
+  "engines": {
+    "node": ">= 5.10.0"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/nearinfinity/node-bplist-parser.git"
   },
   "dependencies": {
-    "big-integer": "^1.6.7"
+    "big-integer": "^1.6.43"
   }
 }

--- a/test/parseTest.js
+++ b/test/parseTest.js
@@ -2,158 +2,103 @@
 
 // tests are adapted from https://github.com/TooTallNate/node-plist
 
-var path = require('path');
-var nodeunit = require('nodeunit');
-var bplist = require('../');
+const assert = require('assert');
+const path = require('path');
+const bplist = require('../');
 
-module.exports = {
-  'iTunes Small': function (test) {
-    var file = path.join(__dirname, "iTunes-small.bplist");
-    var startTime1 = new Date();
+describe('bplist-parser', function () {
+  it('iTunes Small', async function () {
+    const file = path.join(__dirname, "iTunes-small.bplist");
+    const startTime1 = new Date();
 
-    bplist.parseFile(file, function (err, dicts) {
-      if (err) {
-        throw err;
-      }
+    const [dict] = await bplist.parseFile(file);
+    const endTime = new Date();
+    console.log('Parsed "' + file + '" in ' + (endTime - startTime1) + 'ms');
+    assert.equal(dict['Application Version'], "9.0.3");
+    assert.equal(dict['Library Persistent ID'], "6F81D37F95101437");
+  });
 
-      var endTime = new Date();
-      console.log('Parsed "' + file + '" in ' + (endTime - startTime1) + 'ms');
-      var dict = dicts[0];
-      test.equal(dict['Application Version'], "9.0.3");
-      test.equal(dict['Library Persistent ID'], "6F81D37F95101437");
-      test.done();
-    });
-  },
+  it('sample1', async function () {
+    const file = path.join(__dirname, "sample1.bplist");
+    const startTime = new Date();
 
-  'sample1': function (test) {
-    var file = path.join(__dirname, "sample1.bplist");
-    var startTime = new Date();
+    const [dict] = await bplist.parseFile(file);
+    const endTime = new Date();
+    console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
 
-    bplist.parseFile(file, function (err, dicts) {
-      if (err) {
-        throw err;
-      }
+    assert.equal(dict['CFBundleIdentifier'], 'com.apple.dictionary.MySample');
+  });
 
-      var endTime = new Date();
-      console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
-      var dict = dicts[0];
-      test.equal(dict['CFBundleIdentifier'], 'com.apple.dictionary.MySample');
-      test.done();
-    });
-  },
+  it('sample2', async function () {
+    const file = path.join(__dirname, "sample2.bplist");
+    const startTime = new Date();
 
-  'sample2': function (test) {
-    var file = path.join(__dirname, "sample2.bplist");
-    var startTime = new Date();
+    const [dict] = await bplist.parseFile(file);
+    const endTime = new Date();
+    console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
 
-    bplist.parseFile(file, function (err, dicts) {
-      if (err) {
-        throw err;
-      }
+    assert.equal(dict['PopupMenu'][2]['Key'], "\n        #import <Cocoa/Cocoa.h>\n\n#import <MacRuby/MacRuby.h>\n\nint main(int argc, char *argv[])\n{\n  return macruby_main(\"rb_main.rb\", argc, argv);\n}\n");
+  });
 
-      var endTime = new Date();
-      console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
-      var dict = dicts[0];
-      test.equal(dict['PopupMenu'][2]['Key'], "\n        #import <Cocoa/Cocoa.h>\n\n#import <MacRuby/MacRuby.h>\n\nint main(int argc, char *argv[])\n{\n  return macruby_main(\"rb_main.rb\", argc, argv);\n}\n");
-      test.done();
-    });
-  },
+  it('airplay', async function () {
+    const file = path.join(__dirname, "airplay.bplist");
+    const startTime = new Date();
 
-  'airplay': function (test) {
-    var file = path.join(__dirname, "airplay.bplist");
-    var startTime = new Date();
+    const [dict] = await bplist.parseFile(file);
+    const endTime = new Date();
+    console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
 
-    bplist.parseFile(file, function (err, dicts) {
-      if (err) {
-        throw err;
-      }
+    assert.equal(dict['duration'], 5555.0495000000001);
+    assert.equal(dict['position'], 4.6269989039999997);
+  });
 
-      var endTime = new Date();
-      console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
+  it('utf16', async function () {
+    const file = path.join(__dirname, "utf16.bplist");
+    const startTime = new Date();
 
-      var dict = dicts[0];
-      test.equal(dict['duration'], 5555.0495000000001);
-      test.equal(dict['position'], 4.6269989039999997);
-      test.done();
-    });
-  },
+    const [dict] = await bplist.parseFile(file);
+    const endTime = new Date();
+    console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
 
-  'utf16': function (test) {
-    var file = path.join(__dirname, "utf16.bplist");
-    var startTime = new Date();
+    assert.equal(dict['CFBundleName'], 'sellStuff');
+    assert.equal(dict['CFBundleShortVersionString'], '2.6.1');
+    assert.equal(dict['NSHumanReadableCopyright'], '©2008-2012, sellStuff, Inc.');
+  });
 
-    bplist.parseFile(file, function (err, dicts) {
-      if (err) {
-        throw err;
-      }
+  it('utf16chinese', async function () {
+    const file = path.join(__dirname, "utf16_chinese.plist");
+    const startTime = new Date();
 
-      var endTime = new Date();
-      console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
+    const [dict] = await bplist.parseFile(file);
+    const endTime = new Date();
+    console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
 
-      var dict = dicts[0];
-      test.equal(dict['CFBundleName'], 'sellStuff');
-      test.equal(dict['CFBundleShortVersionString'], '2.6.1');
-      test.equal(dict['NSHumanReadableCopyright'], '©2008-2012, sellStuff, Inc.');
-      test.done();
-    });
-  },
+    assert.equal(dict['CFBundleName'], '天翼阅读');
+    assert.equal(dict['CFBundleDisplayName'], '天翼阅读');
+  });
 
-  'utf16chinese': function (test) {
-    var file = path.join(__dirname, "utf16_chinese.plist");
-    var startTime = new Date();
+  it('uid', async function () {
+    const file = path.join(__dirname, "uid.bplist");
+    const startTime = new Date();
 
-    bplist.parseFile(file, function (err, dicts) {
-      if (err) {
-        throw err;
-      }
+    const [dict] = await bplist.parseFile(file);
+    const endTime = new Date();
+    console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
 
-      var endTime = new Date();
-      console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
+    assert.deepEqual(dict['$objects'][1]['NS.keys'], [{UID:2}, {UID:3}, {UID:4}]);
+    assert.deepEqual(dict['$objects'][1]['NS.objects'], [{UID: 5}, {UID:6}, {UID:7}]);
+    assert.deepEqual(dict['$top']['root'], {UID:1});
+  });
 
-      var dict = dicts[0];
-      test.equal(dict['CFBundleName'], '天翼阅读');
-      test.equal(dict['CFBundleDisplayName'], '天翼阅读');
-      test.done();
-    });
-  },
+  it('int64', async function () {
+    const file = path.join(__dirname, "int64.bplist");
+    const startTime = new Date();
 
+    const [dict] = await bplist.parseFile(file);
+    const endTime = new Date();
+    console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
 
-
-  'uid': function (test) {
-    var file = path.join(__dirname, "uid.bplist");
-    var startTime = new Date();
-
-    bplist.parseFile(file, function (err, dicts) {
-      if (err) {
-        throw err;
-      }
-
-      var endTime = new Date();
-      console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
-
-      var dict = dicts[0];
-      test.deepEqual(dict['$objects'][1]['NS.keys'], [{UID:2}, {UID:3}, {UID:4}]);
-      test.deepEqual(dict['$objects'][1]['NS.objects'], [{UID: 5}, {UID:6}, {UID:7}]);
-      test.deepEqual(dict['$top']['root'], {UID:1});
-      test.done();
-    });
-  },
-  
-  'int64': function (test) {
-    var file = path.join(__dirname, "int64.bplist");
-    var startTime = new Date();
-
-    bplist.parseFile(file, function (err, dicts) {
-      if (err) {
-        throw err;
-      }
-
-      var endTime = new Date();
-      console.log('Parsed "' + file + '" in ' + (endTime - startTime) + 'ms');
-      var dict = dicts[0];
-      test.equal(dict['zero'], '0');
-      test.equal(dict['int64item'], '12345678901234567890');
-      test.done();
-    });
-  }
-};
+    assert.equal(dict['zero'], '0');
+    assert.equal(dict['int64item'], '12345678901234567890');
+  });
+});


### PR DESCRIPTION
- Enhancement: Offer Promise API
- Update: Avoid deprecated `Buffer` constructor in favor of `Buffer.from` (and set Node engines to 5.10.0, min version for `Buffer.from`)
- Refactoring: Have source prefer `const` and use `let` over `var` 
- Refactoring: Avoid unnecessary `else` after `return`
- Testing: Switch from end-of-lifed nodeunit to mocha
- npm: Add npm-recommended `package-lock.json`
- npm: Add recommended `package.json` properties
- npm: Update big-integer
