### PR TITLE
Add parseBuffer to TypeScript types

### DIFF
--- a/bplistParser.d.ts
+++ b/bplistParser.d.ts
@@ -2,6 +2,7 @@ declare namespace bPlistParser {
   type CallbackFunction<T = any> = (error: Error|null, result: [T]) => void
   export function parseFile<T = any>(fileNameOrBuffer: string|Buffer, callback?: CallbackFunction<T>): Promise<[T]>
   export function parseFileSync<T = any>(fileNameOrBuffer: string|Buffer): [T]
+  export function parseBuffer<T = any>(buffer: string|Buffer): [T]
 }
 
 export = bPlistParser


### PR DESCRIPTION
This pull request adds the `parseBuffer` TypeScript type, fixes https://github.com/joeferner/node-bplist-parser/issues/32.