### PR TITLE
Fix #36: parseFile() throws TypeError on fs error if no callback is p…

### DIFF
--- a/bplistParser.js
+++ b/bplistParser.js
@@ -43,7 +43,8 @@ exports.parseFile = function (fileNameOrBuffer, callback) {
     fs.readFile(fileNameOrBuffer, function (err, data) {
       if (err) {
         reject(err);
-        return callback(err);
+        if (callback) callback(err);
+        return;
       }
       tryParseBuffer(data);
     });


### PR DESCRIPTION
…rovided