### PR TITLE
Cleanups after ESM-conversion

### DIFF
--- a/bplistParser.d.ts
+++ b/bplistParser.d.ts
@@ -1,7 +1,9 @@
 export declare namespace bPlistParser {
+  var maxObjectCount: number;
+  var maxObjectSize: number;
   type CallbackFunction<T = any> = (error: Error|null, result: [T]) => void
   export function parseFile<T = any>(fileNameOrBuffer: string|Buffer, callback?: CallbackFunction<T>): Promise<[T]>
   export function parseFileSync<T = any>(fileNameOrBuffer: string|Buffer): [T]
   export function parseBuffer<T = any>(buffer: string|Buffer): [T]
 }
-
+export default bPlistParser;

--- a/bplistParser.js
+++ b/bplistParser.js
@@ -7,8 +7,8 @@
 import fs from 'fs';
 const debug = false;
 
-export const maxObjectSize = 100 * 1000 * 1000; // 100Meg
-export const maxObjectCount = 32768;
+export var maxObjectSize = 100 * 1000 * 1000; // 100Meg
+export var maxObjectCount = 32768;
 
 // EPOCH = new SimpleDateFormat("yyyy MM dd zzz").parse("2001 01 01 GMT").getTime();
 // ...but that's annoying in a static initializer because it can throw exceptions, ick.


### PR DESCRIPTION
I made two mistakes in #42.

1. I assumed `maxObjectCount` and `maxObjectSize` was constant. 
2. I missed the default export in type-definitions. 

This should fix this and add types reflecting the mutability of `maxObject*`